### PR TITLE
Add Vivliostyle Foundation info

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -2,15 +2,17 @@ murakami:
   en: Shinyu Murakami
   ja: 村上 真雄
   email: murakami@vivliostyle.org
-  role_ja: Vivliostyle.org プロジェクト・リーダー
-  role_en: Vivliostyle.org Project Leader
+  role_en: Representative Director, Vivliostyle Project Leader
+  role_ja: 代表理事、Vivliostyle プロジェクト・リーダー
 florian:
   en: Florian Rivoal
   ja: リボアル・フロリアン
   email: vivliostyle@florian.rivoal.net
-  role_ja: W3C CSS WG Invited Expert
-  role_en: W3C CSS WG Invited Expert
+  role_en: Director, W3C CSS WG Invited Expert
+  role_ja: 理事、W3C CSS WG Invited Expert
 johannes:
   en: Johannes Wilm
+  ja: ヨハネス・ウィルム
   email: johannes@fiduswriter.org
-  role_en: W3C Editing Taskforce Invited Expert
+  role_en: Director, W3C Editing Taskforce Invited Expert
+  role_ja: 理事、W3C Editing Taskforce Invited Expert

--- a/index.md
+++ b/index.md
@@ -33,3 +33,13 @@ For this purpose, we carry out activities such as:
 * Promotion and education of Vivliostyle and CSS typesetting
 * Promote standardization in cooperation with groups related to standard technologies such as Web, publishing, and accessibility
 * Cooperation with external projects working with Vivliostyle
+
+<div style="margin: 2em 0 1em; text-align: right">
+<div><strong>Vivliostyle Foundation</strong></div>
+<div>Established in August 2018</div>
+<br>
+{% assign people = "murakami, florian, johannes" | split: ", " %}
+{% for a in people %}
+<div><strong><a href="mailto:{{ site.data.people[a].email }}">{{ site.data.people[a].en }}</a></strong>&ensp;({{ site.data.people[a].role_en }})</div>
+{% endfor %}
+</div>

--- a/ja/index.md
+++ b/ja/index.md
@@ -25,3 +25,13 @@ Vivliostyleは、電子出版＝Web出版の時代にマッチする新しい組
 * VivliostyleとCSS組版の普及啓発・教育
 * Web・出版・アクセシビリティ等の標準技術に関する諸団体と連携して標準化推進
 * Vivliostyleと連携する外部のプロジェクトとの協力
+
+<div style="margin: 2em 0 1em; text-align: right">
+<div><strong><ruby>Vivliostyle Foundation<rt style="font-size: 75%">一般社団法人ビブリオスタイル</rt></ruby></strong></div>
+<div>2018年8月&ensp;設立</div>
+<br>
+{% assign people = "murakami, florian, johannes" | split: ", " %}
+{% for a in people %}
+<div><strong><a href="mailto:{{ site.data.people[a].email }}">{{ site.data.people[a].ja }}</a></strong>&ensp;({{ site.data.people[a].role_ja }})</div>
+{% endfor %}
+</div>


### PR DESCRIPTION
This update adds the following info in "About Vivliostyle Foundation" section of the Home page:

English:
```
Vivliostyle Foundation
Established in August 2018

Shinyu Murakami (Representative Director, Vivliostyle Project Leader)
Florian Rivoal (Director, W3C CSS WG Invited Expert)
Johannes Wilm (Director, W3C Editing Taskforce Invited Expert)
```

Japanese:
```
一般社団法人ビブリオスタイル
Vivliostyle Foundation
2018年8月 設立

村上 真雄 (代表理事、Vivliostyle プロジェクト・リーダー)
リボアル・フロリアン (理事、W3C CSS WG Invited Expert)
ヨハネス・ウィルム (理事、W3C Editing Taskforce Invited Expert)
```

The people info is retrieved from `_data/people.yml` file.
