### PR TITLE
Fix Heading ID override（見出しのIDを上書きしない）

### DIFF
--- a/_data/global_footer.yml
+++ b/_data/global_footer.yml
@@ -2,11 +2,11 @@ en:
   - title: Getting Started
     links:
       - title: Vivliostyle Viewer
-        url: /getting-started#Vivliostyle Viewer v2.0.0
+        url: /getting-started#vivliostyle-viewer
       - title: Vivliostyle CLI
-        url: /getting-started#Vivliostyle CLI v2.0.0
+        url: /getting-started#vivliostyle-cli
       - title: Vivliostyle Pub
-        url: /getting-started#Vivliostyle Pub (Initial version will be released later this year) v0.0.0
+        url: /getting-started#vivliostyle-pub
       - title: Samples
         url: /samples
       - title: Download
@@ -14,9 +14,9 @@ en:
   - title: Documents
     links:
       - title: User Guide
-        url: /documents#User Guide
+        url: /documents#user-guide
       - title: Contribution Guide
-        url: /documents#Contribution Guide
+        url: /documents#contribution-guide
   - title: Community
     links:
       - title: Community
@@ -24,7 +24,7 @@ en:
       - title: About Us
         url: /about-us
       - title: Sponsors
-        url: /about-us#Become a sponsor of Vivliostyle
+        url: /about-us#become-a-sponsor-of-vivliostyle
       - title: History
         url: /history
   - title: Others
@@ -41,16 +41,16 @@ ja:
   - title: 使ってみる
     links:
       - title: Vivliostyle Viewer
-        url: /ja/getting-started#Vivliostyle Viewer v2.0.0
+        url: /ja/getting-started#vivliostyle-viewer
       - title: Vivliostyle CLI
-        url: /ja/getting-started#Vivliostyle CLI v2.0.0
+        url: /ja/getting-started#vivliostyle-cli
       - title: Vivliostyle Pub
-        url: /ja/getting-started#Vivliostyle Pub (初期版を今年中に公開予定) v0.0.0
+        url: /ja/getting-started#vivliostyle-pub
       - title: サンプル
         url: /ja/samples
       - title: ダウンロード
         url: /ja/download
-  - title: 開発する
+  - title: ドキュメント
     links:
       - title: ユーザーガイド
         url: /ja/documents#ユーザーガイド
@@ -63,7 +63,7 @@ ja:
       - title: 私たちについて
         url: /ja/about-us
       - title: スポンサー募集
-        url: /ja/about-us#Vivliostyle のスポンサーになりませんか
+        url: /ja/about-us#vivliostyle-のスポンサーになりませんか
       - title: Vivliostyle のなりたち
         url: /ja/history
   - title: その他

--- a/_includes/generate-heading-links.html
+++ b/_includes/generate-heading-links.html
@@ -2,12 +2,12 @@
   const headings = document.querySelectorAll("h2, h3, h4, h5, h6");
 
   headings.forEach(function(heading) {
-    const text = heading.innerText;
-    heading.setAttribute("id", text);
-
-    let link = document.createElement("a");
-    link.setAttribute("href", "#" + text);
-    link.classList.add("heading__link");
-    heading.insertBefore(link, heading.firstChild);
+    const id = heading.id;
+    if (id) {
+      let link = document.createElement("a");
+      link.setAttribute("href", "#" + id);
+      link.classList.add("heading__link");
+      heading.insertBefore(link, heading.firstChild);
+    }
   });
 </script>

--- a/_posts/2020-06-11-fy2019-activity-report-is-now-available.md
+++ b/_posts/2020-06-11-fy2019-activity-report-is-now-available.md
@@ -5,11 +5,11 @@ image: /assets/posts/2020-06-11-fy2019-activity-report-is-now-available/fy2019-a
 author:
   - ogwata
 ---
-<div style="float: right; margin: 0 0 1em 1em;"><a href="https://vivliostyle.org/about-us/#FY2019%20Activity%20Report"><img src="/assets/posts/2020-06-11-fy2019-activity-report-is-now-available/fy2019-activity-report-en.png" alt="FY2019 Activity Report" style="width: 300px; box-shadow: 1px 2px 2.5px 1.5px grey;" /></a></div>
+<div style="float: right; margin: 0 0 1em 1em;"><a href="/about-us/#fy2019-activity-report"><img src="/assets/posts/2020-06-11-fy2019-activity-report-is-now-available/fy2019-activity-report-en.png" alt="FY2019 Activity Report" style="width: 300px; box-shadow: 1px 2px 2.5px 1.5px grey;" /></a></div>
 
 Vivliostyle Foundation's fiscal year is April 1 to March 31. We are pleased to announce that we have prepared the activity report for the second fiscal year, April 1, 2019, to March 31, 2020, as follows:
 
-- [About Us -> FY2019 Activity Report](https://vivliostyle.org/about-us/#FY2019%20Activity%20Report)
+- [About Us -> FY2019 Activity Report](/about-us/#fy2019-activity-report)
 
 To make it easier to read, the activity report is also available for viewing in our main product, Vivliostyle Viewer. Check out the results of CSS typesetting.
 

--- a/_posts/ja/2020-06-11-fy2019-activity-report-is-now-available.md
+++ b/_posts/ja/2020-06-11-fy2019-activity-report-is-now-available.md
@@ -5,11 +5,11 @@ image: /assets/posts/2020-06-11-fy2019-activity-report-is-now-available/fy2019-a
 author:
   - ogwata
 ---
-<div style="float: right; margin: 0 0 1em 1em;"><a href="https://vivliostyle.org/ja/about-us/#2019%E5%B9%B4%E5%BA%A6%E4%BA%8B%E6%A5%AD%E5%A0%B1%E5%91%8A%E6%9B%B8"><img src="/assets/posts/2020-06-11-fy2019-activity-report-is-now-available/fy2019-activity-report-ja.png" alt="FY2019 Activity Report" style="width: 300px; box-shadow: 1px 2px 2.5px 1.5px grey;" /></a></div>
+<div style="float: right; margin: 0 0 1em 1em;"><a href="/ja/about-us/#2019年度事業報告書"><img src="/assets/posts/2020-06-11-fy2019-activity-report-is-now-available/fy2019-activity-report-ja.png" alt="FY2019 Activity Report" style="width: 300px; box-shadow: 1px 2px 2.5px 1.5px grey;" /></a></div>
 
 一般社団法人ビブリオスタイルの事業年度は4/1〜3/31です。下記の通り、第2期となる2019年4月1日〜2020年3月31日の事業報告書を作成しましたのでお知らせします。
 
-- [私たちについて>2019年度事業報告書](https://vivliostyle.org/ja/about-us/#2019年度事業報告書)
+- [私たちについて>2019年度事業報告書](/ja/about-us/#2019年度事業報告書)
 
 読みやすいように、事業報告書は当法人のメインプロダクトである Vivliostyle Viewer でも閲覧できるようにしてあります。CSS組版による誌面をご確認いただければと思います。
 

--- a/faq.md
+++ b/faq.md
@@ -20,7 +20,7 @@ title: FAQ
 
 First, you need to start a local web server so that your local HTML documents can be accessed in the browser. Here explains how to use Node.js's http-server as the local web server.
 
-If Node.js is not installed, install Node.js first. 👉 <span class="url"><https://nodejs.org></span>
+If Node.js is not installed, install Node.js first. 👉<span class="url"><https://nodejs.org></span>
 
 In your Terminal (or Command Prompt on Windows), install http-server with the following command:
 
@@ -75,7 +75,7 @@ An example of displaying unzipped EPUB on GitHub:
 
 ### How to enable the TOC panel?
 
-The TOC (Table of Contents) panel is enabled by setting [**Book Mode**](#What%20is%20Book%20Mode%3F) in Vivliostyle Viewer and the HTML file contains a TOC element, e.g.:
+The TOC (Table of Contents) panel is enabled by setting [**Book Mode**](#what-is-book-mode) in Vivliostyle Viewer and the HTML file contains a TOC element, e.g.:
 
 ```html
 <nav role="doc-toc">
@@ -90,11 +90,11 @@ The TOC (Table of Contents) panel is enabled by setting [**Book Mode**](#What%20
 
 👉User Guide: [TOC panel](https://docs.vivliostyle.org/#/user-guide#toc-panel)
 
-👉See also: [How to make a TOC?](#How%20to%20make%20a%20TOC%3f)
+👉See also: [How to make a TOC?](#how-to-make-a-toc)
 
 ### How to typeset and view multiple HTML files concatenated?
 
-When you enable [**Book Mode**](#What%20is%20Book%20Mode%3F) with Vivliostyle Viewer, and load an HTML file containing a table of contents element with links to other HTML file as shown below, the HTML files linked from the table of contents element are also loaded and typeset in succession:
+When you enable [**Book Mode**](#what-is-book-mode) with Vivliostyle Viewer, and load an HTML file containing a table of contents element with links to other HTML file as shown below, the HTML files linked from the table of contents element are also loaded and typeset in succession:
 
 ```html
 <nav role="doc-toc">
@@ -113,15 +113,15 @@ When you enable [**Book Mode**](#What%20is%20Book%20Mode%3F) with Vivliostyle Vi
 
 👉User Guide: [Web publications (multi-HTML documents)](https://docs.vivliostyle.org/#/user-guide#web-publications-multi-html-documents)
 
-👉See also: [How to make a TOC?](#How%20to%20make%20a%20TOC%3f)
+👉See also: [How to make a TOC?](#how-to-make-a-toc)
 
 ### What is Book Mode?
 
 Book Mode is enabled by checking the **Book Mode** checkbox in the [Vivliostyle Viewer](https://vivliostyle.org/viewer/) UI or by adding `&bookMode=true` to the URL parameter. In this mode, the following features are enabled:
 
-- [Navigation from the TOC panel](#How%20to%20enable%20the%20TOC%20panel%3F)
-- [Typeset and view multiple HTML files concatenated](#How%20to%20typeset%20and%20view%20multiple%20HTML%20files%20concatenated%3F)
-- [Typeset and view unzipped EPUB](#How%20to%20view%20EPUB%3F)
+- [Navigation from the TOC panel](#how-to-enable-the-toc-panel)
+- [Typeset and view multiple HTML files concatenated](#how-to-typeset-and-view-multiple-html-files-concatenated)
+- [Typeset and view unzipped EPUB](#how-to-view-epub)
 
 ### How to make the text size variable?
 
@@ -272,8 +272,8 @@ nav li a::after {
 For real examples, see the samples with "table of contents" tag in the [Vivliostyle Samples](https://vivliostyle.org/samples/) page.
 
 👉See also:
-- [How to enable the TOC panel?](#How%20to%20enable%20the%20TOC%20panel%3F)
-- [How to typeset and view multiple HTML files concatenated?](#How%20to%20typeset%20and%20view%20multiple%20HTML%20files%20concatenated%3F)
+- [How to enable the TOC panel?](#how-to-enable-the-toc-panel)
+- [How to typeset and view multiple HTML files concatenated?](#how-to-typeset-and-view-multiple-html-files-concatenated)
 
 ### How to embed math formulas (MathML, TeX or AsciiMath)
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -26,7 +26,7 @@ title: Getting Started
 
 
 {% capture viewer %}
-## Vivliostyle Viewer <span class="tip">{{ site.data.project.viewer.version }}</span>
+<h2 id="vivliostyle-viewer">Vivliostyle Viewer <span class="tip">{{ site.data.project.viewer.version }}</span></h2>
 
 - A browser-based formatting engine that reads HTML and displays the results of the typesetting in the browser.
 - In order to typeset and display local files, you need to start the web server (see FAQ for details).
@@ -92,7 +92,7 @@ $ vivliostyle preview index.html
 
 
 {% capture cli %}
-## Vivliostyle CLI <span class="tip">{{ site.data.project.cli.version }}</span>
+<h2 id="vivliostyle-cli">Vivliostyle CLI <span class="tip">{{ site.data.project.cli.version }}</span></h2>
 
 - CSS typesetting on the command line with output to PDF.
 - PDF/X-1a output supported by merging PRESS-READY in v2. [Ghostscript](https://www.ghostscript.com/) and [Xpdf](http://www.xpdfreader.com/) are required for this feature. See [PRESS-READY](https://github.com/vibranthq/press-ready/blob/master/README.md) for more information.
@@ -107,7 +107,7 @@ $ vivliostyle preview index.html
 
 <!-- pub -->
 {% capture pub %}
-## Vivliostyle Pub <small>(Initial version will be released later this year)</small> <span class="tip">{{ site.data.project.pub.version }}</span>
+<h2 id="vivliostyle-pub">Vivliostyle Pub <small>(Initial version will be released later this year)</small> <span class="tip">{{ site.data.project.pub.version }}</span></h2>
 
 Edit text/Markdown/HTML in the left pane and preview the formatted results in the right pane.
 

--- a/ja/faq.md
+++ b/ja/faq.md
@@ -15,13 +15,13 @@ lang: ja
 
 ### ローカル環境で Vivliostyle Viewer を使うには？
 
-👉 [Vivliostyle Viewer の配布パッケージの README（日本語）](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/viewer/README.ja.md) の「配布パッケージ `vivliostyle-viewer-*.zip` を使う場合」をご覧ください。
+👉[Vivliostyle Viewer の配布パッケージの README（日本語）](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/viewer/README.ja.md) の「配布パッケージ `vivliostyle-viewer-*.zip` を使う場合」をご覧ください。
 
 ### オンラインの Vivliostyle Viewer でローカルの文書を表示するには？
 
 まず、ローカルWebサーバーを起動して、ローカルのHTML文書にブラウザからアクセスできるようにします。ここでは、ローカルWebサーバーとして Node.js の http-server を使う方法を説明します。
 
-Node.js がインストールされていない場合はまずそのインストールをします。👉 <span class="url"><https://nodejs.org></span>
+Node.js がインストールされていない場合はまずそのインストールをします。👉<span class="url"><https://nodejs.org></span>
 
 ターミナル（Windows ではコマンドプロンプト）で、次のコマンドにより http-server をインストールします：
 
@@ -75,7 +75,7 @@ GitHub上に公開されているZIP解凍済みのEPUBファイルを表示す�
 
 ### 目次パネルを有効にするには？
 
-HTMLファイル内に次のような目次要素がある場合、Vivliostyle Viewer で [**Book Mode**](#Book%20Mode%20とは？) を指定することで、目次パネルが有効になります。
+HTMLファイル内に次のような目次要素がある場合、Vivliostyle Viewer で [**Book Mode**](#book-mode-とは) を指定することで、目次パネルが有効になります。
 
 ```html
 <nav role="doc-toc">
@@ -90,11 +90,11 @@ HTMLファイル内に次のような目次要素がある場合、Vivliostyle V
 
 👉ユーザーガイドの [目次パネル](https://docs.vivliostyle.org/#/ja/user-guide#%E7%9B%AE%E6%AC%A1%E3%83%91%E3%83%8D%E3%83%AB)
 
-👉次も参照: [目次を作るには？](#目次を作るには？)
+👉次も参照: [目次を作るには？](#目次を作るには)
 
 ### 複数のHTMLファイルを連結して組版表示するには？
 
-Vivliostyle Viewer で [**Book Mode**](#Book%20Mode%20とは？) を指定した場合、次のように別のHTMLファイルへのリンクからなる目次要素を含むHTMLファイルをロードすると、目次要素内からリンクされているHTMLファイルも連続してロードされて、それらが連結された組版表示となります：
+Vivliostyle Viewer で [**Book Mode**](#book-mode-とは) を指定した場合、次のように別のHTMLファイルへのリンクからなる目次要素を含むHTMLファイルをロードすると、目次要素内からリンクされているHTMLファイルも連続してロードされて、それらが連結された組版表示となります：
 
 ```html
 <nav role="doc-toc">
@@ -113,15 +113,15 @@ Vivliostyle Viewer で [**Book Mode**](#Book%20Mode%20とは？) を指定した
 
 👉ユーザーガイドの [Web出版物（複数HTML文書）](https://docs.vivliostyle.org/#/ja/user-guide#web%E5%87%BA%E7%89%88%E7%89%A9%EF%BC%88%E8%A4%87%E6%95%B0html%E6%96%87%E6%9B%B8%EF%BC%89)
 
-👉次も参照: [目次を作るには？](#目次を作るには？)
+👉次も参照: [目次を作るには？](#目次を作るには)
 
 ### Book Mode とは？
 
 [Vivliostyle Viewer](https://vivliostyle.org/viewer/) のUIの **Book Mode** チェックボックスをチェック、あるいはURLパラメータに `&bookMode=true` を追加することにより Book Mode が有効になります。このモードでは、次の機能が有効になります：
 
-- [目次パネルからのナビゲーションが有効](#目次パネルを有効にするには？)
-- [複数の HTML ファイルを連結して組版表示](#複数のHTMLファイルを連結して組版表示するには？)
-- [EPUB（ZIP解凍済み）の組版表示](#EPUBを閲覧するには？)
+- [目次パネルからのナビゲーションが有効](#目次パネルを有効にするには)
+- [複数の HTML ファイルを連結して組版表示](#複数のhtmlファイルを連結して組版表示するには)
+- [EPUB（ZIP解凍済み）の組版表示](#epubを閲覧するには)
 
 ### 文字サイズを可変にするには？
 
@@ -273,8 +273,8 @@ nav li a::after {
 実例については、Vivliostyleのサンプル紹介ページ <span class="url"><https://vivliostyle.org/ja/samples/></span> の「目次」タグが付いたサンプルをご覧ください。
 
 👉以下も参照:
-- [目次パネルを有効にするには？](#目次パネルを有効にするには？)
-- [複数のHTMLファイルを連結して組版表示するには？](#複数のHTMLファイルを連結して組版表示するには？)
+- [目次パネルを有効にするには？](#目次パネルを有効にするには)
+- [複数のHTMLファイルを連結して組版表示するには？](#複数のhtmlファイルを連結して組版表示するには)
 
 ### 数式（MathML、TeX、AsciiMath）を埋め込むには？
 

--- a/ja/faq.md
+++ b/ja/faq.md
@@ -149,7 +149,7 @@ Vivliostyle Viewer は、スタイルシートによるページサイズの指�
 
 ## Vivliostyle CLI についての FAQ
 
-### PDFの「しおり」(Bookmarks)」を有効にするには？
+### PDFの「しおり」(Bookmarks)を有効にするには？
 
 [Vivliostyle CLI](https://www.npmjs.com/package/@vivliostyle/cli) v2.1 以降では、組版する文書の目次データを使ってPDFの「しおり」(Bookmarks) を自動生成することができます。PDF の「しおり」は、Adobe Acrobat のような PDF 閲覧ソフトで目次ナビゲーションに利用できるものです。
 

--- a/ja/getting-started.md
+++ b/ja/getting-started.md
@@ -27,7 +27,7 @@ lang: ja
 
 
 {% capture viewer %}
-## Vivliostyle Viewer <span class="tip">{{ site.data.project.viewer.version }}</span>
+<h2 id="vivliostyle-viewer">Vivliostyle Viewer <span class="tip">{{ site.data.project.viewer.version }}</span></h2>
 
 - ブラウザで動作する組版エンジン。HTML を読み込んで組版結果をブラウザに表示します。
 - ローカルのファイルを組版・表示するには、webサーバー起動が必要です（くわしくはFAQをご覧ください）。
@@ -89,7 +89,7 @@ $ vivliostyle preview index.html
 
 
 {% capture cli %}
-## Vivliostyle CLI <span class="tip">{{ site.data.project.cli.version }}</span>
+<h2 id="vivliostyle-cli">Vivliostyle CLI <span class="tip">{{ site.data.project.cli.version }}</span></h2>
 
 - コマンドラインから CSS 組版をして表示します。PDF に出力できます。
 - v2において press-ready をマージしたことにより、PDF/X-1a 出力がサポートされました（本機能には [Ghostscript](https://www.ghostscript.com/) と [Xpdf](http://www.xpdfreader.com/) が必要です。詳細は [press-ready](https://github.com/vibranthq/press-ready/blob/master/README.md) をご参照ください）。
@@ -104,7 +104,7 @@ $ vivliostyle preview index.html
 
 <!-- pub -->
 {% capture pub %}
-## Vivliostyle Pub <small>(初期版を今年中に公開予定)</small> <span class="tip">{{ site.data.project.pub.version }}</span>
+<h2 id="vivliostyle-pub">Vivliostyle Pub <small>(初期版を今年中に公開予定)</small> <span class="tip">{{ site.data.project.pub.version }}</span></h2>
 
 左ペインでテキスト / Markdown / HTML を入力・編集すると、右ペインで組版結果がプレビューできます。
 

--- a/ja/sponsors.md
+++ b/ja/sponsors.md
@@ -15,7 +15,7 @@ indexing: false
 
 上記は英語ページですが、以下に和訳があります。ご参照ください。
 
-[GitHub Sponsors で Vivliostyle を支援しませんか](https://vivliostyle.org/ja/blog/2020/04/29/become-a-sponsor-to-vivliostyle-via-github-sponsors/#GitHub%20Sponsors%20%E3%81%A7%20Vivliostyle%20%E3%82%92%E6%94%AF%E6%8F%B4%E3%81%97%E3%81%BE%E3%81%9B%E3%82%93%E3%81%8B)
+[GitHub Sponsors で Vivliostyle を支援しませんか](/ja/blog/2020/04/29/become-a-sponsor-to-vivliostyle-via-github-sponsors/)
 {% endcapture %}
 
 


### PR DESCRIPTION
Markdownから変換されたHTMLファイルには既に次のような標準的な規則で見出しのテキストからIDが自動生成されている：

- 大文字の小文字化
- スペースをハイフンに変換
- 句読点類を削除

しかし、このIDが `_includes/generate-heading-links.html` 内のJavaScriptにより、単に見出しのテキスト内容になるように上書きされていた。
IDとしてあまり適切でないし、
HTMLソースにあるIDとDOM上で作られるIDが違っていて混乱するし、
VFMやdocuteで生成されるIDと違うのも不便である。

そこでこのID生成は削除。すでにHTMLに付与されているIDだけ使うことにした。
それにあわせて内部リンクを修正。

その他、マイナーな修正少し。