### PR TITLE
トップページにスポンサーページへのリンクを追加

### DIFF
--- a/index.md
+++ b/index.md
@@ -118,7 +118,7 @@ The current amount of support is **$48.00** per month. Please consider helping u
 {% include all-sponsors.html %}
 
 <ol class="list--medium">
-  {% include button/primary.html url=site.data.account.github_sponsor.url text="Become a sponsor to Vivliostyle" %}
+  {% include button/primary.html url="/sponsors" text="Become a sponsor to Vivliostyle" %}
 </ol>
 {% endcapture %}
 

--- a/ja/index.md
+++ b/ja/index.md
@@ -119,7 +119,7 @@ Vivliostyleは独立したオープンソースプロジェクトです。私た
 {% include all-sponsors.html %}
 
 <ol class="list--medium">
-  {% include button/primary.html url=site.data.account.github_sponsor.url text="GitHub スポンサーに応募する" %}
+  {% include button/primary.html url="/ja/sponsors" text="スポンサーに応募する" %}
 </ol>
 {% endcapture %}
 

--- a/ja/sponsors.md
+++ b/ja/sponsors.md
@@ -2,7 +2,6 @@
 layout: page
 title: あなたも Vivliostyle のスポンサーになりませんか
 lang: ja
-indexing: false
 ---
 
 

--- a/sponsors.md
+++ b/sponsors.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: How about supporting Vivliostyle
-indexing: false
 ---
 
 


### PR DESCRIPTION
- トップページにあったGitHub Sponsorsへのリンクをスポンサーページへのリンクに変更
- 未公開のためつけていた `indexing: false` を削除