### PR TITLE
最近のVivliostyle更新を反映した修正

### DIFF
--- a/_data/sample.yml
+++ b/_data/sample.yml
@@ -35,7 +35,7 @@ tag:
   - &tag_tachikiri_nuritashi
     name:
       ja: 裁切り塗り足し
-      en: Fill a bleed
+      en: Bleed
   - &tag_flexbox
     name:
       ja: Flexbox
@@ -102,13 +102,13 @@ link_name:
     en: flexible page size (horizontal text)
   - &link_name_page_float_on
     ja: ページフロート有
-    en: with a page float
+    en: with page floats
   - &link_name_page_float_off
     ja: ページフロート無
-    en: no page float
+    en: no page floats
   - &link_name_justification_on
     ja: justification ＆ hyphenation 有
-    en: with a justification & hyphenation
+    en: with justification & hyphenation
   - &link_name_justification_off
     ja: justification ＆ hyphenation 無
     en: no justification & hyphenation
@@ -117,7 +117,7 @@ link_name:
 categories:
   - name:
       ja: 単純な長文組版
-      en: Typesetting simple and long sentences
+      en: Typesetting simple and long texts
     samples:
       - name:
           ja: ごん狐（書籍）
@@ -232,7 +232,7 @@ categories:
             en:  from Peter Sorotokin’s [Adaptive Layout](https://github.com/sorotokin/adaptive-layout)
   - name:
       ja: 段組／図版の段抜き配置
-      en: A illustration stretching across several columns
+      en: Multi-column layout with figures spanning columns
     samples:
       - name:
           ja: 白馬岳（雑誌）

--- a/documents.md
+++ b/documents.md
@@ -56,8 +56,8 @@ title: Documents
 {% capture reference %}
 ## References
 
-- [Core API Reference](https://docs.vivliostyle.org/#/api)
 - [Supported CSS Features](https://docs.vivliostyle.org/#/supported-css-features)
+- [Core API Reference](https://docs.vivliostyle.org/#/api)
 {% endcapture %}
 
 
@@ -78,9 +78,11 @@ Vivliostyle project discusses development matters on Slack.
 
 
 {% capture plan_core_description %}
+- [Support CSS Grid Layout #539](https://github.com/vivliostyle/vivliostyle.js/issues/539)
+- [Support CSS custom properties (variables) #540](https://github.com/vivliostyle/vivliostyle.js/issues/540)
+- [Support for running elements? #424](https://github.com/vivliostyle/vivliostyle.js/issues/424)
 - [Support the font-variant-\* longhands #592](https://github.com/vivliostyle/vivliostyle.js/issues/592)
 - [add support for user-select #587](https://github.com/vivliostyle/vivliostyle.js/issues/587)
-- [Support non-unzipped EPUB loading #541](https://github.com/vivliostyle/vivliostyle.js/issues/541)
 {% endcapture %}
 
 
@@ -90,7 +92,7 @@ Vivliostyle project discusses development matters on Slack.
 
 {% capture plan_cli_description %}
 - [Add --grayscale option #44](https://github.com/vivliostyle/vivliostyle-cli/issues/44)
-- [Need to post-fix PDF for Japanese/Chinese text accessibility #40](https://github.com/vivliostyle/vivliostyle-cli/issues/40)
+- [TOC generation in an entry file #115](https://github.com/vivliostyle/vivliostyle-cli/issues/115)
 {% endcapture %}
 
 

--- a/download.md
+++ b/download.md
@@ -5,6 +5,9 @@ title: Download
 
 
 {% capture contents %}
+
+💡To use Vivliostyle in a local environment, the recommend tool is Vivliostyle CLI, which includes the Vivliostyle Viewer. 👉[Vivliostyle CLI User Guide](https://docs.vivliostyle.org/#/vivliostyle-cli)
+
 - Vivliostyle.js [GitHub](https://github.com/vivliostyle/vivliostyle.js) [npm](https://www.npmjs.com/org/vivliostyle)
   - Vivliostyle Viewer [GitHub](https://github.com/vivliostyle/vivliostyle.js/tree/master/packages/viewer/) [npm](https://www.npmjs.com/package/@vivliostyle/viewer/)
     - [All Releases](https://vivliostyle.github.io/)
@@ -13,8 +16,8 @@ title: Download
       - [Online Vivliostyle Viewer](/viewer/)
       - [Release notes](https://github.com/vivliostyle/vivliostyle.js/releases)
     - [Development Release (Canary)](https://vivliostyle.github.io/#canary-release-equivalent-to-master)
-      - [Download Canary Release](https://vivliostyle.now.sh/vivliostyle-viewer-canary.zip)
-      - [Online Vivliostyle Viewer (Canary)](https://vivliostyle.now.sh/)
+      - [Download Canary Release](https://vivliostyle.vercel.app/vivliostyle-viewer-canary.zip)
+      - [Online Vivliostyle Viewer (Canary)](https://vivliostyle.vercel.app/)
       - [Change Log](https://github.com/vivliostyle/vivliostyle.js/tree/master/CHANGELOG.md)
   - Vivliostyle Core [GitHub](https://github.com/vivliostyle/vivliostyle.js/tree/master/packages/core) [npm](https://www.npmjs.com/package/@vivliostyle/core)
 - Vivliostyle CLI [GitHub](https://github.com/vivliostyle/vivliostyle-cli) [npm](https://www.npmjs.com/package/@vivliostyle/cli)

--- a/faq.md
+++ b/faq.md
@@ -12,9 +12,13 @@ title: FAQ
 {% capture license %}
 ## Vivliostyle Viewer FAQ
 
+User Guide: [Vivliostyle Viewer User Guide](https://docs.vivliostyle.org/#/vivliostyle-viewer)
+
 ### How to use Vivliostyle Viewer in a local environment?
 
-👉See [Vivliostyle Viewer's README: To use the distribution package `vivliostyle-viewer-*.zip`](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/viewer/README.md#to-use-the-distribution-package-vivliostyle-viewer-zip).
+To use Vivliostyle Viewer in a local environment, it is convenient to use the preview command of the Vivliostyle CLI. For information on how to install and use the Vivliostyle CLI, see [Vivliostyle CLI User Guide](https://docs.vivliostyle.org/#/vivliostyle-cli), and [Preview the typesetting results](https://docs.vivliostyle.org/#/vivliostyle-cli#preview-the-typesetting-results).
+
+👉[Vivliostyle Viewer User Guide: To use Vivliostyle Viewer in a local environment](https://docs.vivliostyle.org/#/vivliostyle-viewer#to-use-vivliostyle-viewer-in-a-local-environment)
 
 ### How to view my local documents with the online Vivliostyle Viewer?
 
@@ -68,6 +72,8 @@ An example of displaying unzipped EPUB on GitHub:
   <span class="url"><https://vivliostyle.org/viewer/#src=https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/&bookMode=true></span>
 
 👉[Vivliostyle Viewer User Guide: EPUB](https://docs.vivliostyle.org/#/vivliostyle-viewer#epub)
+
+To view (or convert to PDF) EPUB in a local environment, it is convenient to use Vivliostyle CLI. Soo [Vivliostyle CLI User Guide](https://docs.vivliostyle.org/#/vivliostyle-cli), [Generate PDF from EPUB](https://docs.vivliostyle.org/#/vivliostyle-cli#generate-pdf-from-epub) and [Preview the typesetting results](https://docs.vivliostyle.org/#/vivliostyle-cli#preview-the-typesetting-results).
 
 ### How to integrate Vivliostyle Viewer into my website?
 
@@ -148,6 +154,8 @@ You can also specify the page size by **User Style Preferences** → **Page Size
 ```
 
 ## Vivliostyle CLI FAQ
+
+User Guide: [Vivliostyle CLI User Guide](https://docs.vivliostyle.org/#/vivliostyle-cli)
 
 ### How to enable PDF Bookmarks?
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -29,7 +29,6 @@ title: Getting Started
 <h2 id="vivliostyle-viewer">Vivliostyle Viewer <span class="tip">{{ site.data.project.viewer.version }}</span></h2>
 
 - A browser-based formatting engine that reads HTML and displays the results of the typesetting in the browser.
-- In order to typeset and display local files, you need to start the web server (see FAQ for details).
 
 <ol class="list--medium">
   {% include button/primary.html url=site.data.project.viewer.url text="Use Vivliostyle Viewer" %}
@@ -38,7 +37,8 @@ title: Getting Started
 
 {% include frame-list.html frames=viewer_frames %}
 
-There is also a [downloadable version](https://github.com/vivliostyle/vivliostyle.js/releases) that can be used on private networks, so you can do what you want with it without going through us.
+For more information about Vivliostyle Viewer, see [Vivliostyle Viewer User Guide](https://docs.vivliostyle.org/#/vivliostyle-viewer).
+
 {% endcapture %}
 
 
@@ -102,6 +102,9 @@ $ vivliostyle preview index.html
 </ol>
 
 {% include frame-list.html frames=cli_frames %}
+
+For more information about Vivliostyle CLI, see [Vivliostyle CLI User Guide](https://docs.vivliostyle.org/#/vivliostyle-cli).
+
 {% endcapture %}
 
 

--- a/ja/documents.md
+++ b/ja/documents.md
@@ -57,8 +57,8 @@ lang: ja
 {% capture reference %}
 ## 📚 リファレンス
 
-- [Core API リファレンス](https://docs.vivliostyle.org/#/ja/api)
 - [サポートする CSS 機能](https://docs.vivliostyle.org/#/ja/supported-css-features)
+- [Core API リファレンス](https://docs.vivliostyle.org/#/ja/api)
 {% endcapture %}
 
 
@@ -79,9 +79,11 @@ Vivliostyle プロジェクトでは、開発方針などをSlack上で話し合
 
 
 {% capture plan_core_description %}
+- [Support CSS Grid Layout #539](https://github.com/vivliostyle/vivliostyle.js/issues/539)
+- [Support CSS custom properties (variables) #540](https://github.com/vivliostyle/vivliostyle.js/issues/540)
+- [Support for running elements? #424](https://github.com/vivliostyle/vivliostyle.js/issues/424)
 - [Support the font-variant-\* longhands #592](https://github.com/vivliostyle/vivliostyle.js/issues/592)
 - [add support for user-select #587](https://github.com/vivliostyle/vivliostyle.js/issues/587)
-- [Support non-unzipped EPUB loading #541](https://github.com/vivliostyle/vivliostyle.js/issues/541)
 {% endcapture %}
 
 
@@ -91,7 +93,7 @@ Vivliostyle プロジェクトでは、開発方針などをSlack上で話し合
 
 {% capture plan_cli_description %}
 - [Add --grayscale option #44](https://github.com/vivliostyle/vivliostyle-cli/issues/44)
-- [Need to post-fix PDF for Japanese/Chinese text accessibility #40](https://github.com/vivliostyle/vivliostyle-cli/issues/40)
+- [TOC generation in an entry file #115](https://github.com/vivliostyle/vivliostyle-cli/issues/115)
 {% endcapture %}
 
 

--- a/ja/download.md
+++ b/ja/download.md
@@ -6,6 +6,9 @@ lang: ja
 
 
 {% capture contents %}
+
+💡Vivliostyle をローカル環境で使うには Vivliostyle CLI がお勧めです。Vivliostyle CLI には Vivliostyle Viewer が統合されています。👉[Vivliostyle CLI ユーザーガイド](https://docs.vivliostyle.org/#/ja/vivliostyle-cli)
+
 - Vivliostyle.js [GitHub](https://github.com/vivliostyle/vivliostyle.js) [npm](https://www.npmjs.com/org/vivliostyle)
   - Vivliostyle Viewer [GitHub](https://github.com/vivliostyle/vivliostyle.js/tree/master/packages/viewer/) [npm](https://www.npmjs.com/package/@vivliostyle/viewer/)
     - [すべてのリリース](https://vivliostyle.github.io/)
@@ -14,8 +17,8 @@ lang: ja
       - [オンライン Vivliostyle Viewer](/viewer/)
       - [Release notes](https://github.com/vivliostyle/vivliostyle.js/releases)
     - [最新開発版リリース (Canary)](https://vivliostyle.github.io/#canary-release-equivalent-to-master)
-      - [最新開発版のダウンロード (Canary)](https://vivliostyle.now.sh/vivliostyle-viewer-canary.zip)
-      - [オンライン Vivliostyle Viewer (Canary)](https://vivliostyle.now.sh/)
+      - [最新開発版のダウンロード (Canary)](https://vivliostyle.vercel.app/vivliostyle-viewer-canary.zip)
+      - [オンライン Vivliostyle Viewer (Canary)](https://vivliostyle.vercel.app/)
       - [Change Log](https://github.com/vivliostyle/vivliostyle.js/tree/master/CHANGELOG.md)
   - Vivliostyle Core [GitHub](https://github.com/vivliostyle/vivliostyle.js/tree/master/packages/core) [npm](https://www.npmjs.com/package/@vivliostyle/core)
 - Vivliostyle CLI [GitHub](https://github.com/vivliostyle/vivliostyle-cli) [npm](https://www.npmjs.com/package/@vivliostyle/cli)

--- a/ja/faq.md
+++ b/ja/faq.md
@@ -13,9 +13,13 @@ lang: ja
 {% capture license %}
 ## Vivliostyle Viewer についての FAQ
 
+ユーザーガイド: [Vivliostyle Viewer ユーザーガイド](https://docs.vivliostyle.org/#/ja/vivliostyle-viewer)
+
 ### ローカル環境で Vivliostyle Viewer を使うには？
 
-👉[Vivliostyle Viewer の配布パッケージの README（日本語）](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/viewer/README.ja.md) の「配布パッケージ `vivliostyle-viewer-*.zip` を使う場合」をご覧ください。
+Vivliostyle Viewer をローカル環境で利用するには、Vivliostyle CLI の preview コマンドを使うのが便利です。Vivliostyle CLI のインストール方法と使い方については、[Vivliostyle CLI ユーザーガイド](https://docs.vivliostyle.org/#/ja/vivliostyle-cli)、preview コマンドについては [組版結果のプレビュー](https://docs.vivliostyle.org/#/ja/vivliostyle-cli#%E7%B5%84%E7%89%88%E7%B5%90%E6%9E%9C%E3%81%AE%E3%83%97%E3%83%AC%E3%83%93%E3%83%A5%E3%83%BC) をご覧ください。
+
+👉[Vivliostyle Viewer ユーザーガイド: Vivliostyle Viewer をローカル環境で利用するには](https://docs.vivliostyle.org/#/ja/vivliostyle-viewer#vivliostyle-viewer-%E3%82%92%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E7%92%B0%E5%A2%83%E3%81%A7%E5%88%A9%E7%94%A8%E3%81%99%E3%82%8B%E3%81%AB%E3%81%AF)
 
 ### オンラインの Vivliostyle Viewer でローカルの文書を表示するには？
 
@@ -68,6 +72,8 @@ GitHub上に公開されているZIP解凍済みのEPUBファイルを表示す�
   <span class="url"><https://vivliostyle.org/viewer/#src=https://github.com/IDPF/epub3-samples/tree/master/30/accessible_epub_3/&bookMode=true></span>
 
 👉[Vivliostyle Viewer ユーザーガイド: EPUB](https://docs.vivliostyle.org/#/ja/vivliostyle-viewer#epub)
+
+ローカル環境で EPUB を閲覧または PDF に変換をするには Vivliostyle CLI が便利です。[Vivliostyle CLI ユーザーガイド](https://docs.vivliostyle.org/#/ja/vivliostyle-cli) の [EPUB から PDF を生成](https://docs.vivliostyle.org/#/ja/vivliostyle-cli#epub-%E3%81%8B%E3%82%89-pdf-%E3%82%92%E7%94%9F%E6%88%90) および [組版結果のプレビュー](https://docs.vivliostyle.org/#/ja/vivliostyle-cli#%E7%B5%84%E7%89%88%E7%B5%90%E6%9E%9C%E3%81%AE%E3%83%97%E3%83%AC%E3%83%93%E3%83%A5%E3%83%BC) をご覧ください。
 
 ### Webサイトに Vivliostyle Viewer を組み込むには？
 
@@ -148,6 +154,8 @@ Vivliostyle Viewer は、スタイルシートによるページサイズの指�
 ```
 
 ## Vivliostyle CLI についての FAQ
+
+ユーザーガイド: [Vivliostyle CLI ユーザーガイド](https://docs.vivliostyle.org/#/ja/vivliostyle-cli)
 
 ### PDFの「しおり」(Bookmarks)を有効にするには？
 

--- a/ja/getting-started.md
+++ b/ja/getting-started.md
@@ -30,7 +30,6 @@ lang: ja
 <h2 id="vivliostyle-viewer">Vivliostyle Viewer <span class="tip">{{ site.data.project.viewer.version }}</span></h2>
 
 - ブラウザで動作する組版エンジン。HTML を読み込んで組版結果をブラウザに表示します。
-- ローカルのファイルを組版・表示するには、webサーバー起動が必要です（くわしくはFAQをご覧ください）。
 
 <ol class="list--medium">
   {% include button/primary.html url=site.data.project.viewer.url text="Vivliostyle Viewer を使う" %}
@@ -39,7 +38,8 @@ lang: ja
 
 {% include frame-list.html frames=viewer_frames %}
 
-他にプライベートネットワークで使える[ダウンロード版](https://github.com/vivliostyle/vivliostyle.js/releases)もあります。用途に合わせてお使いいただけます。
+Vivliostyle Viewer について詳しくは [Vivliostyle Viewer ユーザーガイド](https://docs.vivliostyle.org/#/ja/vivliostyle-viewer) を参照してください。
+
 {% endcapture %}
 
 
@@ -99,6 +99,9 @@ $ vivliostyle preview index.html
 </ol>
 
 {% include frame-list.html frames=cli_frames %}
+
+Vivliostyle CLI について詳しくは [Vivliostyle CLI ユーザーガイド](https://docs.vivliostyle.org/#/ja/vivliostyle-cli) を参照してください。
+
 {% endcapture %}
 
 


### PR DESCRIPTION
Issue #72 についての修正など。

- [サンプルページ（英語）の不自然な英語を修正](https://github.com/vivliostyle/vivliostyle.org/commit/bc8b00c06ddf98ff32311f02191f7cd6378e419b)
- [「ドキュメント」ページ修正](https://github.com/vivliostyle/vivliostyle.org/commit/5b91a3f54207b958d77760ef78a9ce328fde7054)
  - 「リファレンス」で「サポートする CSS 機能」を先頭に
  - 「今後の開発予定」に載せている issue を更新
- [「ダウンロード」ページ修正](https://github.com/vivliostyle/vivliostyle.org/commit/a957cccf01eb615e6237aa526a65863143fc4556)
  - 最初に「💡Vivliostyle をローカル環境で使うには Vivliostyle CLI がお勧めです。Vivliostyle CLI には Vivliostyle Viewer が統合されています。👉Vivliostyle CLI ユーザーガイド」
  - Canary 版の URL の "vivliostyle.now.sh" を "vivliostyle.vercel.app" に修正"
- [「使ってみる」ページ修正](https://github.com/vivliostyle/vivliostyle.org/commit/45b804e463e22d790746b9617b12ee3bf550e115)
  - 「ローカルのファイルを組版・表示するには、webサーバー起動が必要です」を削除
  - ユーザーガイドへの参照を入れた
- [FAQページのVivliostyle ViewerとVivliostyle CLIを修正](https://github.com/vivliostyle/vivliostyle.org/commit/2d4c24605e450a59073df798d0e3cf6fcae9ff7e)
  - ユーザーガイドへの参照をFAQのVivliostyle ViewerとVivliostyle CLIそれぞれの最初に入れた
  - 「Vivliostyle Viewer をローカル環境で利用するには、Vivliostyle CLI の preview コマンドを使うのが便利です。...」を入れた
  - 「ローカル環境で EPUB を閲覧または PDF に変換をするには Vivliostyle CLI が便利です。...」を入れた