### PR TITLE
ユーザーガイドにVFMのドキュメントを追加

### DIFF
--- a/_includes/fetch-guide-urls.html
+++ b/_includes/fetch-guide-urls.html
@@ -5,7 +5,10 @@
       const headings = await fetchHeadings(get_url);
 
       headings.forEach(function(name) {
-        element.insertAdjacentHTML("beforeend", listTemplate(name, base_url));
+        // 目次を除く
+        if(!name.toLowerCase().match(/^(目次|table of contents)$/)) {
+          element.insertAdjacentHTML("beforeend", listTemplate(name, base_url));
+        }
       });
     } catch(error) {
       console.log(error);

--- a/documents.md
+++ b/documents.md
@@ -32,6 +32,14 @@ title: Documents
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/create-book.md"
 %}
 
+### VFM
+<ul id="vfm-list"></ul>
+{% include fetch-guide-url.html
+  id="vfm-list"
+  url="https://vivliostyle.github.io/vfm/#/vfm"
+  get_url="https://api.github.com/repos/vivliostyle/vfm/contents/docs/vfm.md"
+%}
+
 ## 🛠 Contribution Guides
 
 ### Vivliostyle.js

--- a/documents.md
+++ b/documents.md
@@ -32,7 +32,7 @@ title: Documents
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/create-book.md"
 %}
 
-### VFM
+### Vivliostyle Flavored Markdown (VFM)
 <ul id="vfm-list"></ul>
 {% include fetch-guide-url.html
   id="vfm-list"

--- a/ja/documents.md
+++ b/ja/documents.md
@@ -33,7 +33,7 @@ lang: ja
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/ja/create-book.md"
 %}
 
-### VFM
+### Vivliostyle Flavored Markdown (VFM)
 <ul id="vfm-list"></ul>
 {% include fetch-guide-url.html
   id="vfm-list"

--- a/ja/documents.md
+++ b/ja/documents.md
@@ -33,6 +33,14 @@ lang: ja
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/ja/create-book.md"
 %}
 
+### VFM
+<ul id="vfm-list"></ul>
+{% include fetch-guide-url.html
+  id="vfm-list"
+  url="https://vivliostyle.github.io/vfm/#/vfm"
+  get_url="https://api.github.com/repos/vivliostyle/vfm/contents/docs/vfm.md"
+%}
+
 ## 🛠 コントリビューションガイド
 
 ### Vivliostyle.js


### PR DESCRIPTION
#79 

- 見出しを取得してそこへのリンクを貼るようにしているが、見出しテキストが `(目次|table of contents)` の場合はスキップするようにした
- VFMのドキュメントへのリンクを追加した
  - 日本語版はないようなので、日本語ページも英語ドキュメントへのリンク
  - ![image](https://user-images.githubusercontent.com/7820884/124340875-4a98dd00-dbf3-11eb-86ed-c4d89ec4797a.png)
