### PR TITLE
Themesのドキュメントへのリンクを追加

### DIFF
--- a/documents.md
+++ b/documents.md
@@ -32,6 +32,13 @@ title: Documents
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/create-book.md"
 %}
 
+### Vivliostyle Themes
+<ul>
+  <li><a href="https://vivliostyle.github.io/themes/#/spec.md">Spec</a></li>
+  <li><a href="https://vivliostyle.github.io/themes/#/tutorial/step0.md">Development Tutorial</a></li>
+  <li><a href="https://vivliostyle.github.io/themes/#/official.md">Operational Guidelines</a></li>
+</ul>
+
 ### Vivliostyle Flavored Markdown (VFM)
 <ul id="vfm-list"></ul>
 {% include fetch-guide-url.html

--- a/ja/documents.md
+++ b/ja/documents.md
@@ -33,6 +33,13 @@ lang: ja
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/ja/create-book.md"
 %}
 
+### Vivliostyle Themes
+<ul>
+  <li><a href="https://vivliostyle.github.io/themes/#/ja/spec.md">仕様</a></li>
+  <li><a href="https://vivliostyle.github.io/themes/#/ja/tutorial/step0.md">開発チュートリアル</a></li>
+  <li><a href="https://vivliostyle.github.io/themes/#/ja/official.md">運用ガイドライン</a></li>
+</ul>
+
 ### Vivliostyle Flavored Markdown (VFM)
 <ul id="vfm-list"></ul>
 {% include fetch-guide-url.html


### PR DESCRIPTION
#105 

他のドキュメント（CLIやVFMなど）については、ページ内のH2タグを探して自動でリンクを掲載するようにしています。しかしThemesのドキュメントはそのような形式になっていない（H2へのリンクを載せると単位が細かすぎる）ので、ひとまず主要なページへのリンクを手作業で掲載するようにしました。