### PR TITLE
Vivliostyle Pub α版へのリンクを追加

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -25,7 +25,7 @@ pub:
   name: Vivliostyle Pub
   version: v0.0.0
   github: https://github.com/vivliostyle/vivliostyle-pub
-  # url:
+  url: https://vivliostyle-pub-develop.vercel.app
   sample:
     ja: /ja/samples/
     en: /samples/

--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ With Vivliostyle Pub, you can create printable PDF from your browser.
 </ol>
 
 <ol class="list--medium">
-  {% include button/disabled.html url=site.data.project.pub.url text="Try Vivliostyle Pub (will be released by the end of 2021)" %}
+  {% include button/primary.html url=site.data.project.pub.url text="Try Vivliostyle Pub (Now in alpha version)" %}
 </ol>
 {% endcapture %}
 
@@ -88,8 +88,8 @@ Vivliostyle is developing the following products.
   project3_description="Typesetting from command line and generate PDF."
   project4_src="/assets/projects/project4.svg"
   project4_name=site.data.project.pub.name
-  project4_link=site.data.project.pub.github
-  project4_description="Enter markdown and you can see the typesetting results immediately."
+  project4_link=site.data.project.pub.url
+  project4_description="Enter markdown and you can see the typesetting results immediately (Now in alpha version)"
 %}
 
 Other libraries for developers include ["Vivliostyle Core"]({{ site.data.project.core.github }}), the core of the typesetting engine, and ["Vivliostyle Print"]({{ site.data.project.print.github }}), which embeds printing functionality into websites.

--- a/ja/index.md
+++ b/ja/index.md
@@ -50,7 +50,7 @@ Vivliostyle Pub を使えば、印刷可能なPDFをブラウザ上から作成�
 </ol>
 
 <ol class="list--medium">
-  {% include button/disabled.html url=site.data.project.pub.url text="Vivliostyle Pub を試す（2022年4月中にアルファ版を公開予定）" %}
+  {% include button/primary.html url=site.data.project.pub.url text="Vivliostyle Pub を試す（ただ今アルファ版を公開中）" %}
 </ol>
 {% endcapture %}
 
@@ -89,8 +89,8 @@ Vivliostyle には開発中も含め、次のプロダクトがあります。
   project3_description="コマンドラインから組版して PDF を生成"
   project4_src="/assets/projects/project4.svg"
   project4_name=site.data.project.pub.name
-  project4_link=site.data.project.pub.github
-  project4_description="マークダウンを入力すると組版結果が見られる（2022年4月中にアルファ版を公開予定）"
+  project4_link=site.data.project.pub.url
+  project4_description="マークダウンを入力すると組版結果が見られる（ただ今アルファ版を公開中）"
 %}
 
 このほか開発者向けライブラリとして、組版エンジンのコア [“Vivliostyle Core”]({{ site.data.project.core.github }})、およびWebサイトに印刷機能を組み込む [“Vivliostyle Print”]({{ site.data.project.print.github }}) があります。


### PR DESCRIPTION
## 日本語ページ
<img width="965" alt="image" src="https://user-images.githubusercontent.com/7820884/170474146-dcba7683-23c7-4e54-8704-aa38fc3f116f.png">
<img width="966" alt="image" src="https://user-images.githubusercontent.com/7820884/170474174-45f5dee6-faf9-49cd-a9d7-1e033d7ebfc2.png">
「Vivliostyleとは？」のセクションでは、「Vivliostyle Pub」の文字にvercelへのリンクを張っています。

## 英語ページ
<img width="965" alt="image" src="https://user-images.githubusercontent.com/7820884/170474076-a865d046-a35b-4e75-baec-b85bd896c858.png">
<img width="966" alt="image" src="https://user-images.githubusercontent.com/7820884/170474109-826040b3-6499-400a-9550-7d7767c95701.png">
