### PR TITLE
Update Vivliostyle License FAQ: change Copyright Trim-marks Inc. to Daishinsha Inc.

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -300,10 +300,12 @@ References:
 The Vivliostyle source code has the following copyright notation: (e.g., in [epub.ts](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/src/vivliostyle/epub.ts))
 
 > * Copyright 2013 Google, Inc.
-> * Copyright 2015 Trim-marks Inc.
+> * Copyright 2015 Daishinsha Inc.
 > * Copyright 2018 Vivliostyle Foundation
 
 "Copyright 2013 Google, Inc." is because Vivliostyle was originally developed based on [EPUB Adaptive Layout JavaScript-based implementation ("Adapt")](https://github.com/sorotokin/adaptive-layout), which was developed by Peter Sorotokin of Google. Google owns the rights to the source code from this original project.
+
+"Copyright 2015 Daishinsha Inc." is because Daishinsha Inc. acquired the rights from Trim-marks Inc. in 2024.
 
 Trim-marks Inc. (formerly Vivliostyle Inc.) developed Vivliostyle from 2015 to March 2018. The rights to Vivliostyle source code written during this period belong to Trim-marks Inc. In addition, the license of Vivliostyle was originally Apache License 2.0, inheriting "Adapt" of the original project, but changed to AGPLv3 from February 2017.
 

--- a/ja/faq.md
+++ b/ja/faq.md
@@ -303,10 +303,12 @@ Vivliostyle のソースコードには、次のようなコピーライト表�
 （[epub.ts](https://github.com/vivliostyle/vivliostyle.js/blob/master/packages/core/src/vivliostyle/epub.ts) の例）
 
 > * Copyright 2013 Google, Inc.
-> * Copyright 2015 Trim-marks Inc.
+> * Copyright 2015 Daishinsha Inc.
 > * Copyright 2018 Vivliostyle Foundation
 
 「Copyright 2013 Google, Inc.」とあるのは、Vivliostyle がもともと、Google に所属する Peter Sorotokin 氏によって開発された [EPUB Adaptive Layout JavaScript-based implementation ("Adapt")](https://github.com/sorotokin/adaptive-layout) をベースとして開発されたためです。この元プロジェクト由来のソースコードの権利は Google にあります。
+
+「Copyright 2015 Daishinsha Inc.」とあるのは、2024年に株式会社大伸社（Daishinsha Inc.）がTrim-marks社から権利を取得したためです。
 
 Trim-marks 社（旧社名は Vivliostyle Inc.）は、2015年から2018年3月までのあいだ、Vivliostyle の開発の主体でした。この期間に書かれた Vivliostyle ソースコードの権利は Trim-marks 社にあります。また、Vivliostyle のライセンスは当初、元プロジェクトの "Adapt" を継承して Apache License 2.0 でしたが、2017年2月から AGPLv3 に変更されました。
 


### PR DESCRIPTION
Recently, Daishinsha Inc. acquired all software copyrights held by Trim-marks Inc. So changes to the copyright notice were requested.

Related Vivliostyle.js pull request:

- https://github.com/vivliostyle/vivliostyle.js/pull/1310
