### PR TITLE
Remove github-actions from the contributor list

### DIFF
--- a/_includes/fetch-contributors.html
+++ b/_includes/fetch-contributors.html
@@ -27,8 +27,8 @@
     contributors = new Set(contributors.flat());
 
     return [...contributors].filter(function(contributor) {
-      // dependabotでない
-      return contributor != "dependabot[bot]";
+      // dependabot, github-actionsでない
+      return contributor != "dependabot[bot]" && contributor != "github-actions[bot]";
     });
   }
 


### PR DESCRIPTION
http://vivliostyle.org/ja/about-us/ のコントリビューター一覧に `github-actions[bot]` が入っていたのを削除しました。

こちら削除後です↓
<img width="1142" alt="image" src="https://github.com/vivliostyle/vivliostyle.org/assets/7820884/c7c90701-a1e4-4409-9eca-ec364c702200">

補足：
原因は、themesで `github-actions[bot]` によるコミットがあったためです。https://github.com/vivliostyle/themes/graphs/contributors を見る限り、昨年12月ごろからコントリビューター一覧に `github-actions[bot]` が載っていたのではないかと思われます（気づかずすみませんでした :bow:）。