### PR TITLE
U-1F992→u1f992 other

### DIFF
--- a/_data/sponsor.yml
+++ b/_data/sponsor.yml
@@ -42,7 +42,7 @@
             - name: NoBooking
             - name: vvakame
             - name: y-mikou
-            - name: U-1F992
+            - name: u1f992
             - name: sarashino
             - name: yamahige
         - badge: ⭐️

--- a/about-us.md
+++ b/about-us.md
@@ -88,7 +88,6 @@ Vivliostyle open source development relies on volunteer staff. To continue devel
 
 <ol class="list--medium">
   {% include button/primary.html url=site.data.account.github_sponsor.url text="Become a sponsor via Github" %}
-  {% include button/primary.html url="/sponsors" text="Donate by credit card payment" %}
 </ol>
 
 {% include sponsors.html %}

--- a/ja/about-us.md
+++ b/ja/about-us.md
@@ -91,7 +91,6 @@ Vivliostyle はボランティア・スタッフに支えられたオープン�
 
 <ol class="list--medium">
   {% include button/primary.html url=site.data.account.github_sponsor.url text="GitHub スポンサーに応募する" %}
-  {% include button/primary.html url="/ja/sponsors" text="クレジットカード決済で寄付する" %}
 </ol>
 
 {% include sponsors.html %}


### PR DESCRIPTION
about usページでスポンサー名U-1F992をu1f992 に修正、すでにないクレジットカード決済の選択肢を削除