### PR TITLE
ドキュメントページの更新：Vivliostyle CLIの新ドキュメントへのリンクなど

### DIFF
--- a/_includes/fetch-guide-urls.html
+++ b/_includes/fetch-guide-urls.html
@@ -16,7 +16,8 @@
   }
 
   function listTemplate(name, base_url) {
-    const anchor = name.toLowerCase().replace(/\s/g, "-").replace(/[()\/\.]/g, "");
+    const anchor = name.toLowerCase().replace(/\s/g, "-").replace(
+      base_url.startsWith("https://github.com/") ? /[()\/\.（）「」]/g : /[()\/\.]/g, "");
 
     return `
       <li>

--- a/_includes/page/documents.html
+++ b/_includes/page/documents.html
@@ -14,6 +14,12 @@
 
 <section class="section">
   <div class="container">
+    {{ include.contribution | markdownify }}
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
     {{ include.plan | markdownify }}
 
     {{ include.community | markdownify }}

--- a/documents.md
+++ b/documents.md
@@ -8,7 +8,7 @@ title: Documents
 ## 📖 User Guides
 {% include fetch-guide-urls.html %}
 
-### Vivliostyle Viewer
+### [Vivliostyle Viewer](https://docs.vivliostyle.org/#/vivliostyle-viewer)
 <ul id="vivliostyle-viewer-list"></ul>
 {% include fetch-guide-url.html
   id="vivliostyle-viewer-list"
@@ -16,15 +16,65 @@ title: Documents
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/vivliostyle-viewer.md"
 %}
 
-### Vivliostyle CLI
-<ul id="vivliostyle-cli-list"></ul>
+### [Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/index.md)
+<ul>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/getting-started.md">Getting Started</a>
+    <ul id="vivliostyle-cli-getting-started-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/themes-and-css.md">Themes and CSS</a>
+    <ul id="vivliostyle-cli-themes-and-css-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/using-config-file.md">Using Config File</a>
+    <ul id="vivliostyle-cli-using-config-file-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/toc-page.md">Creating Table of Contents Page</a>
+    <ul id="vivliostyle-cli-toc-page-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/cover-page.md">Creating Cover Page</a>
+    <ul id="vivliostyle-cli-cover-page-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/special-output-settings.md">Special Output Settings</a>
+    <ul id="vivliostyle-cli-special-output-settings-list"></ul>
+  </li>
+</ul>
 {% include fetch-guide-url.html
-  id="vivliostyle-cli-list"
-  url="https://docs.vivliostyle.org/#/vivliostyle-cli"
-  get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/vivliostyle-cli.md"
+  id="vivliostyle-cli-getting-started-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/getting-started.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/getting-started.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-themes-and-css-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/themes-and-css.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/themes-and-css.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-using-config-file-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/using-config-file.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/using-config-file.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-toc-page-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/toc-page.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/toc-page.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-cover-page-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/cover-page.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/cover-page.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-special-output-settings-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/special-output-settings.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/special-output-settings.md"
 %}
 
-### Create Book
+### [Create Book](https://docs.vivliostyle.org/#/create-book)
 <ul id="create-book-list"></ul>
 {% include fetch-guide-url.html
   id="create-book-list"
@@ -32,21 +82,24 @@ title: Documents
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/create-book.md"
 %}
 
-### Vivliostyle Themes
+### [Vivliostyle Themes](https://vivliostyle.github.io/themes/#/)
 <ul>
   <li><a href="https://vivliostyle.github.io/themes/#/spec.md">Spec</a></li>
   <li><a href="https://vivliostyle.github.io/themes/#/tutorial/step0.md">Development Tutorial</a></li>
   <li><a href="https://vivliostyle.github.io/themes/#/official.md">Operational Guidelines</a></li>
 </ul>
 
-### Vivliostyle Flavored Markdown (VFM)
+### [Vivliostyle Flavored Markdown (VFM)](https://vivliostyle.github.io/vfm/#/vfm)
 <ul id="vfm-list"></ul>
 {% include fetch-guide-url.html
   id="vfm-list"
   url="https://vivliostyle.github.io/vfm/#/vfm"
   get_url="https://api.github.com/repos/vivliostyle/vfm/contents/docs/vfm.md"
 %}
+{% endcapture %}
 
+
+{% capture contribution %}
 ## 🛠 Contribution Guides
 
 ### Vivliostyle.js
@@ -73,6 +126,9 @@ title: Documents
 
 - [Supported CSS Features](https://docs.vivliostyle.org/#/supported-css-features)
 - [Core API Reference](https://docs.vivliostyle.org/#/api)
+- Vivliostyle CLI API Reference
+  - [Config Reference](https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/config.md)
+  - [JavaScript API](https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/api-javascript.md)
 {% endcapture %}
 
 
@@ -110,6 +166,7 @@ Vivliostyle project discusses development matters on Slack.
 
   guide=guide
   reference=reference
+  contribution=contribution
   plan=plan
   community=community
 %}

--- a/ja/documents.md
+++ b/ja/documents.md
@@ -9,7 +9,7 @@ lang: ja
 ## 📖 ユーザーガイド
 {% include fetch-guide-urls.html %}
 
-### Vivliostyle Viewer
+### [Vivliostyle Viewer](https://docs.vivliostyle.org/#/ja/vivliostyle-viewer)
 <ul id="vivliostyle-viewer-list"></ul>
 {% include fetch-guide-url.html
   id="vivliostyle-viewer-list"
@@ -17,15 +17,65 @@ lang: ja
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/ja/vivliostyle-viewer.md"
 %}
 
-### Vivliostyle CLI
-<ul id="vivliostyle-cli-list"></ul>
+### [Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/index.md)
+<ul>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/getting-started.md">はじめに</a>
+    <ul id="vivliostyle-cli-getting-started-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/themes-and-css.md">テーマと CSS</a>
+    <ul id="vivliostyle-cli-themes-and-css-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/using-config-file.md">構成ファイル</a>
+    <ul id="vivliostyle-cli-using-config-file-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/toc-page.md">目次の作成</a>
+    <ul id="vivliostyle-cli-toc-page-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/cover-page.md">表紙ページの作成</a>
+    <ul id="vivliostyle-cli-cover-page-list"></ul>
+  </li>
+  <li>
+    <a href="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/special-output-settings.md">特別な出力設定</a>
+    <ul id="vivliostyle-cli-special-output-settings-list"></ul>
+  </li>
+</ul>
 {% include fetch-guide-url.html
-  id="vivliostyle-cli-list"
-  url="https://docs.vivliostyle.org/#/ja/vivliostyle-cli"
-  get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/ja/vivliostyle-cli.md"
+  id="vivliostyle-cli-getting-started-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/getting-started.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/ja/getting-started.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-themes-and-css-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/themes-and-css.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/ja/themes-and-css.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-using-config-file-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/using-config-file.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/ja/using-config-file.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-toc-page-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/toc-page.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/ja/toc-page.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-cover-page-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/cover-page.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/ja/cover-page.md"
+%}
+{% include fetch-guide-url.html
+  id="vivliostyle-cli-special-output-settings-list"
+  url="https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/special-output-settings.md"
+  get_url="https://api.github.com/repos/vivliostyle/vivliostyle-cli/contents/docs/ja/special-output-settings.md"
 %}
 
-### Create Book
+### [Create Book](https://docs.vivliostyle.org/#/ja/create-book)
 <ul id="create-book-list"></ul>
 {% include fetch-guide-url.html
   id="create-book-list"
@@ -33,21 +83,24 @@ lang: ja
   get_url="https://api.github.com/repos/vivliostyle/docs.vivliostyle.org/contents/ja/create-book.md"
 %}
 
-### Vivliostyle Themes
+### [Vivliostyle Themes](https://vivliostyle.github.io/themes/#/ja/)
 <ul>
   <li><a href="https://vivliostyle.github.io/themes/#/ja/spec.md">仕様</a></li>
   <li><a href="https://vivliostyle.github.io/themes/#/ja/tutorial/step0.md">開発チュートリアル</a></li>
   <li><a href="https://vivliostyle.github.io/themes/#/ja/official.md">運用ガイドライン</a></li>
 </ul>
 
-### Vivliostyle Flavored Markdown (VFM)
+### [Vivliostyle Flavored Markdown (VFM)](https://vivliostyle.github.io/vfm/#/ja/vfm)
 <ul id="vfm-list"></ul>
 {% include fetch-guide-url.html
   id="vfm-list"
-  url="https://vivliostyle.github.io/vfm/#/vfm"
-  get_url="https://api.github.com/repos/vivliostyle/vfm/contents/docs/vfm.md"
+  url="https://vivliostyle.github.io/vfm/#/ja/vfm"
+  get_url="https://api.github.com/repos/vivliostyle/vfm/contents/docs/ja/vfm.md"
 %}
+{% endcapture %}
 
+
+{% capture contribution %}
 ## 🛠 コントリビューションガイド
 
 ### Vivliostyle.js
@@ -74,6 +127,9 @@ lang: ja
 
 - [サポートする CSS 機能](https://docs.vivliostyle.org/#/ja/supported-css-features)
 - [Core API リファレンス](https://docs.vivliostyle.org/#/ja/api)
+- Vivliostyle CLI API リファレンス
+  - [Config Reference](https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/config.md)
+  - [JavaScript API](https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/api-javascript.md)
 {% endcapture %}
 
 
@@ -111,6 +167,7 @@ Vivliostyle プロジェクトでは、開発方針などをSlack上で話し合
 
   guide=guide
   reference=reference
+  contribution=contribution
   plan=plan
   community=community
 %}


### PR DESCRIPTION
ドキュメントページを更新しました。更新内容は以下の通りです。

- Vivliostyle CLIの新ドキュメントへのリンク
  - 従来の Vivliostyle CLI ユーザーガイド (https://docs.vivliostyle.org/#/ja/vivliostyle-cli) の内容が古くなり、新しいドキュメントが https://github.com/vivliostyle/vivliostyle-cli/blob/main/docs/ja/index.md に作られているため、新しいドキュメントを参照するように直しました。
    - ドキュメント内の見出しを集めたリストを作るためのスクリプト（`_includes/fetch-guide-urls.html` 内）を修正し、新しいドキュメントの見出しへのリンクのURLフラグメントが正しくなるようにしました。
- 日本語版のドキュメントページで「Vivliostyle Flavored Markdown (VFM)」のドキュメントが英語のものになっていたのを日本語のものに修正しました。 (resolves #111)
- 「リファレンス」を「コントリビューションガイド」より先に表示するようにしました。ユーザーが必要とする情報が先で、開発に貢献したい人向けの情報が後にあるほうがよいと考えたためです。
- ユーザーガイドの各プロダクトの見出し（「Vivliostyle Viewer」「Vivliostyle CLI」など）は各プロダクトのドキュメントのトップへのリンクになっているようにしました。

![127 0 0 1_4000_ja_documents_](https://github.com/user-attachments/assets/3712a99b-6db6-4de5-bc22-fd4455601f7e)
