### PR TITLE
docs: `tocTitle`オプションは非推奨となっているため、`toc.title`オプションを使用するよう修正

### DIFF
--- a/ja/tutorials/create-table-of-contents.html
+++ b/ja/tutorials/create-table-of-contents.html
@@ -24,8 +24,9 @@ Vivliostyle の機能を使って目次を自動で作成することができ�
 ```
 module.exports = {
   ...
-  toc: true,
-  tocTitle: '目次',
+  toc: {
+    title: '目次'
+  }
 }
 ```
 


### PR DESCRIPTION
`tocTitle`オプションは非推奨となっているため、`toc.title`オプションを使用するよう修正します。

ref: https://github.com/vivliostyle/vivliostyle-cli/blob/ef01043029440b8275c581cfb9870805ed9c9d56/docs/config.md?plain=1#L59-L60