### PR TITLE
活動報告書に2025年度版（日英）を追加

### DIFF
--- a/about-us.md
+++ b/about-us.md
@@ -31,6 +31,7 @@ Our goal is to develop, publish and disseminate "Vivliostyle", an open source ty
 
 {% capture reports %}
 ### Activity Reports
+- [FY2025 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2025/vf2025report-en.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2025/vf2025report.html)
 - [FY2024 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2024/vf2024report-en.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2024/vf2024report.html)
 - [FY2023 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2023/vf2023report-en.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2023/vf2023report.html)
 - [FY2022 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2022/vf2022report-en.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/en/reports/vivliostyle-report-2022/vf2022report.html)

--- a/ja/about-us.md
+++ b/ja/about-us.md
@@ -35,6 +35,7 @@ lang: ja
 {% capture reports %}
 ### 活動報告書
 
+- [2025年度 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2025/vf2025report-ja.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2025/vf2025report.html)
 - [2024年度 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2024/vf2024report-ja.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2024/vf2024report.html)
 - [2023年度 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2023/vf2023report-ja.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2023/vf2023report.html)
 - [2022年度 (PDF)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2022/vf2022report-ja.pdf) / [(HTML)](https://vivliostyle.github.io/vivliostyle_doc/ja/reports/vivliostyle-report-2022/vf2022report.html)


### PR DESCRIPTION
## 概要

Vivliostyle Foundation の2025年度活動報告書がパブリッシュされたため、About Us ページの「活動報告書 / Activity Reports」セクションに日英それぞれの FY2025 版リンク（PDF / HTML）を追加しました。

参照: vivliostyle_doc の対象PRマージ・公開（`ja/reports/vivliostyle-report-2025`）

## 変更内容

- `ja/about-us.md` — 「活動報告書」リストの先頭に2025年度（PDF / HTML）を追加
- `about-us.md` — 「Activity Reports」リストの先頭に FY2025（PDF / HTML）を追加

既存の降順（新しい年度が先頭）の並びに合わせています。

## 確認

追加した4つのURLがいずれも公開済み（HTTP 200）であることを確認:

- ja PDF / HTML
- en PDF / HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)